### PR TITLE
Update to correct FROM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM blacklabelops/java:openjdk8
+FROM blacklabelops/java:openjdk.8
 MAINTAINER Steffen Bleul <sbl@blacklabelops.com>
 
 ARG CROWD_VERSION=3.3.0
@@ -65,7 +65,6 @@ RUN export MYSQL_DRIVER_VERSION=5.1.44 && \
     wget -P /tmp/ https://letsencrypt.org/certs/lets-encrypt-x2-cross-signed.der && \
     wget -P /tmp/ https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.der && \
     wget -P /tmp/ https://letsencrypt.org/certs/lets-encrypt-x4-cross-signed.der && \
-    keytool -trustcacerts -keystore $KEYSTORE -storepass changeit -noprompt -importcert -alias isrgrootx1 -file /tmp/letsencryptauthorityx1.der && \
     keytool -trustcacerts -keystore $KEYSTORE -storepass changeit -noprompt -importcert -alias isrgrootx2 -file /tmp/letsencryptauthorityx2.der && \
     keytool -trustcacerts -keystore $KEYSTORE -storepass changeit -noprompt -importcert -alias letsencryptauthorityx1 -file /tmp/lets-encrypt-x1-cross-signed.der && \
     keytool -trustcacerts -keystore $KEYSTORE -storepass changeit -noprompt -importcert -alias letsencryptauthorityx2 -file /tmp/lets-encrypt-x2-cross-signed.der && \


### PR DESCRIPTION
openjdk8 points to a 2 year old image on alpine 3.3, which is EOL.

openjdk.8 is likely what is needing to be pointed to, last updated 4 months ago to alpine 3.7.

Removed the import due to:

`keytool error: java.lang.Exception: Certificate not imported, alias <isrgrootx1> already exists`