### PR TITLE
Fixing Dockerfile to reduce size from 782M to 364M

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ ENV CROWD_HOME=/var/atlassian/crowd \
     CROWD_PROXY_SCHEME= \
     KEYSTORE=$JAVA_HOME/jre/lib/security/cacerts
 
+ADD splash-context.xml /opt/crowd/webapps/splash.xml
+
 RUN export MYSQL_DRIVER_VERSION=5.1.44 && \
     export CONTAINER_USER=crowd &&  \
     export CONTAINER_GROUP=crowd &&  \
@@ -74,9 +76,8 @@ RUN export MYSQL_DRIVER_VERSION=5.1.44 && \
     keytool -trustcacerts -keystore $KEYSTORE -storepass changeit -noprompt -importcert -alias letsencryptauthorityx4 -file /tmp/lets-encrypt-x4-cross-signed.der && \
     # Install atlassian ssl tool
     wget -O /home/${CONTAINER_USER}/SSLPoke.class https://confluence.atlassian.com/kb/files/779355358/779355357/1/1441897666313/SSLPoke.class && \
-    chown -R crowd:crowd /home/${CONTAINER_USER}
-ADD splash-context.xml /opt/crowd/webapps/splash.xml
-RUN chown -R crowd:crowd ${CROWD_HOME} && \
+    chown -R crowd:crowd /home/${CONTAINER_USER} && \
+    chown -R crowd:crowd ${CROWD_HOME} && \
     chown -R crowd:crowd ${CROWD_INSTALL} && \
     # Install Tini Zombie Reaper And Signal Forwarder
     export TINI_VERSION=0.9.0 && \


### PR DESCRIPTION
Trying to remove files from a previous layer doesn't actually reduce the image size, so this PR simply combines the two RUN commands into one.  As a result, the newly built image is half of the size.