### PR TITLE
Fixed inconsistent paths, use only /opt/crowd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN export MYSQL_DRIVER_VERSION=5.1.44 && \
     mv /tmp/atlassian-crowd-${CROWD_VERSION} /tmp/crowd && \
     ls -A /tmp && \
     mkdir -p /opt && \
-    mv /tmp/crowd /opt/crowd && \
+    mv /tmp/crowd/* /opt/crowd && \
     mkdir -p ${CROWD_HOME} && \
     mkdir -p ${CROWD_INSTALL}/crowd-webapp/WEB-INF/classes && \
     mkdir -p ${CROWD_INSTALL}/apache-tomcat/lib && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,7 @@ RUN export MYSQL_DRIVER_VERSION=5.1.44 && \
       ${CROWD_INSTALL}/apache-tomcat/lib/mysql-connector-java-${MYSQL_DRIVER_VERSION}-bin.jar  &&  \
     # Adjusting directories
     mv ${CROWD_INSTALL}/apache-tomcat/webapps/ROOT /opt/crowd/splash-webapp && \
-    mv ${CROWD_INSTALL}/apache-tomcat/conf/Catalina/localhost /opt/crowd/webapps && \
-    mkdir -p ${CROWD_INSTALL}/apache-tomcat/conf/Catalina/localhost && \
+    mv ${CROWD_INSTALL}/apache-tomcat/conf/Catalina/localhost/* /opt/crowd/webapps && \
     # Adding letsencrypt-ca to truststore
     wget -P /tmp/ https://letsencrypt.org/certs/letsencryptauthorityx1.der && \
     wget -P /tmp/ https://letsencrypt.org/certs/letsencryptauthorityx2.der && \

--- a/imagescripts/launch.sh
+++ b/imagescripts/launch.sh
@@ -12,24 +12,24 @@ done
 
 if [ -n "$SPLASH_CONTEXT" ]; then
   echo "Installing splash as $SPLASH_CONTEXT"
-  ln -s /opt/crowd/webapps/splash.xml ${SPLASH_CONTEXT}.xml
+  ln -s ${CROWD_INSTALL}/webapps/splash.xml ${SPLASH_CONTEXT}.xml
 fi
 
 if [ -n "$OPENID_CLIENT_CONTEXT" ]; then
   echo "Installing OpenID client at $OPENID_CLIENT_CONTEXT"
-  ln -s /opt/crowd/webapps/openidclient.xml ${OPENID_CLIENT_CONTEXT}.xml
+  ln -s ${CROWD_INSTALL}/webapps/openidclient.xml ${OPENID_CLIENT_CONTEXT}.xml
 fi
 
 if [ -n "$CROWDID_CONTEXT" ]; then
   echo "Installing OpenID server at $CROWDID_CONTEXT"
-  ln -s /opt/crowd/webapps/openidserver.xml ${CROWDID_CONTEXT}.xml
+  ln -s ${CROWD_INSTALL}/webapps/openidserver.xml ${CROWDID_CONTEXT}.xml
 fi
 
 if [ -n "$CROWD_CONTEXT" ]; then
   echo "Installing Crowd at $CROWD_CONTEXT"
-  ln -s /opt/crowd/webapps/crowd.xml ${CROWD_CONTEXT}.xml
+  ln -s ${CROWD_INSTALL}/webapps/crowd.xml ${CROWD_CONTEXT}.xml
 fi
-cd /opt/crowd
+cd ${CROWD_INSTALL}
 
 if [ -z "$DEMO_LOGIN_URL" ]; then
   if [ "$DEMO_CONTEXT" == "ROOT" ]; then
@@ -63,7 +63,7 @@ if [ -n "$CROWD_CONTEXT" ]; then
     CROWDDB_URL="$DATABASE_URL"
   fi
   if [ -n "$CROWDDB_URL" ]; then
-    extract_database_url "$CROWDDB_URL" CROWDDB /opt/crowd/apache-tomcat/lib
+    extract_database_url "$CROWDDB_URL" CROWDDB ${CROWD_INSTALL}/apache-tomcat/lib
     CROWDDB_JDBC_URL="$(xmlstarlet esc "$CROWDDB_JDBC_URL")"
     cat << EOF > webapps/crowd.xml
     <Context docBase="../../crowd-webapp" useHttpOnly="true">
@@ -88,7 +88,7 @@ if [ -n "$CROWDID_CONTEXT" ]; then
     CROWDIDDB_URL="$DATABASE_URL"
   fi
   if [ -n "$CROWDIDDB_URL" ]; then
-    extract_database_url "$CROWDIDDB_URL" CROWDIDDB "/opt/crowd/apache-tomcat/lib"
+    extract_database_url "$CROWDIDDB_URL" CROWDIDDB "${CROWD_INSTALL}/apache-tomcat/lib"
     CROWDIDDB_JDBC_URL="$(xmlstarlet esc "$CROWDIDDB_JDBC_URL")"
     cat << EOF > webapps/openidserver.xml
     <Context docBase="../../crowd-openidserver-webapp">
@@ -100,17 +100,15 @@ if [ -n "$CROWDID_CONTEXT" ]; then
               />
     </Context>
 EOF
-    config_line crowd/build.properties hibernate.dialect "$CROWDIDDB_DIALECT"
+    config_line build.properties hibernate.dialect "$CROWDIDDB_DIALECT"
   fi
 fi
 
-config_line crowd/build.properties demo.url "$DEMO_LOGIN_URL"
-config_line crowd/build.properties openidserver.url "$CROWDID_LOGIN_URL"
-config_line crowd/build.properties crowd.url "$CROWD_URL"
+config_line build.properties demo.url "$DEMO_LOGIN_URL"
+config_line build.properties openidserver.url "$CROWDID_LOGIN_URL"
+config_line build.properties crowd.url "$CROWD_URL"
 
-cd crowd
 ./build.sh
-cd ..
 
 if [ -f "${CROWD_HOME}/crowd.properties" ]; then
   config_line ${CROWD_HOME}/crowd.properties crowd.server.url "$(config_line crowd-webapp/WEB-INF/classes/crowd.properties crowd.server.url)"
@@ -132,6 +130,6 @@ function updateProperties() {
   fi
 }
 
-updateProperties ${CROWD_INSTALL}/crowd/crowd-webapp/WEB-INF/classes/crowd-init.properties crowd.home "${CROWD_HOME}"
+updateProperties ${CROWD_INSTALL}/crowd-webapp/WEB-INF/classes/crowd-init.properties crowd.home "${CROWD_HOME}"
 
-crowd/apache-tomcat/bin/catalina.sh run
+apache-tomcat/bin/catalina.sh run


### PR DESCRIPTION
When pulling for the latest version, I hit a few issues with `/opt/crowd/apache-tomcat/conf/server.xml` not existing. This was because when `/tmp/crowd` was copied over to `/opt/crowd`, instead of merging the folders, it just put the crowd from `/tmp` inside `/opt/crowd`, which resulted in parts of the project using `/opt/crowd`, and other -- more recently edited -- parts using `/opt/crowd/crowd`.

Also made it so `CROWD_INSTALL` is used instead of `/opt/crowd`.

The second edit was because the symlinks in `launch.sh` pointed to nonexistent files, since the actual paths were `${CROWD_INSTALL}/webapps/localhost/splash.xml` (etc.) due to `localhost` being copied over instead of its contents.